### PR TITLE
Remove checkout 'State' field for Malta

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -119,6 +119,7 @@ class WC_Countries {
 			'KR' => array(),
 			'KW' => array(),
 			'LB' => array(),
+			'MT' => array(),
 			'MQ' => array(),
 			'NL' => array(),
 			'NO' => array(),
@@ -961,6 +962,11 @@ class WC_Countries {
 						),
 					),
 					'MQ' => array(
+						'state' => array(
+							'required' => false,
+						),
+					),
+					'MT' => array(
 						'state' => array(
 							'required' => false,
 						),


### PR DESCRIPTION
Malta postal addresses do not include a state, as far as I can tell: https://www.mca.org.mt/content/post-how-should-i-address-letters-and-parcels